### PR TITLE
Add option to omit doubled colors in palettes

### DIFF
--- a/data/com.jeffser.Pigment.gschema.xml
+++ b/data/com.jeffser.Pigment.gschema.xml
@@ -16,6 +16,9 @@
 	  <key name="format-uppercase" type="b">
 	    <default>true</default>
 	  </key>
+	  <key name="omit-doubled-colors" type="b">
+	    <default>false</default>
+	  </key>
 	  <key name="default-format" type="i">
 	    <default>0</default>
 	  </key>

--- a/src/window.py
+++ b/src/window.py
@@ -43,6 +43,7 @@ class PigmentWindow(Adw.ApplicationWindow):
     preferences_dialog = Gtk.Template.Child()
     autogenerate_switch = Gtk.Template.Child()
     uppercase_switch = Gtk.Template.Child()
+    omit_doubled_colors_switch = Gtk.Template.Child()
     default_format_switch = Gtk.Template.Child()
 
     image_mimetypes = (
@@ -53,6 +54,13 @@ class PigmentWindow(Adw.ApplicationWindow):
         'image/bmp',
         'image/tiff'
     )
+
+    def get_unpacked_settings_value(self, setting_name: str):
+        """
+        Helper function to get the value of a setting.
+        """
+
+        return self.settings.get_value(setting_name).unpack()
 
     def action_toggle(self, actions:tuple, state:bool):
         for action in actions:
@@ -80,20 +88,26 @@ class PigmentWindow(Adw.ApplicationWindow):
             colors.append(widget.get_name())
         self.copy_requested('\n'.join(colors))
 
-    def on_generate(self, palette:list):
+    def on_generate(self, palette: list):
         wbox = Adw.WrapBox(
             child_spacing=10,
             line_spacing=10,
             justify=1,
             justify_last_line=1
         )
+
+        # Omit any doubled colors if the setting is enabled
+        if self.get_unpacked_settings_value('omit-doubled-colors'):
+            palette = list(set(palette))
+
         for c in palette:
             color = Color(
                 rgb=c,
-                uppercase=self.settings.get_value('format-uppercase').unpack(),
-                default_index=self.settings.get_value('default-format').unpack()
+                uppercase=self.get_unpacked_settings_value('format-uppercase'),
+                default_index=self.get_unpacked_settings_value('default-format')
             )
             GLib.idle_add(wbox.append, color.button)
+
         GLib.idle_add(self.palette_container.set_child, wbox)
 
     def generate_requested(self):
@@ -129,7 +143,7 @@ class PigmentWindow(Adw.ApplicationWindow):
             if mimetype in self.image_mimetypes:
                 self.picture_overlay.get_child().set_file(file)
                 self.main_stack.set_visible_child_name('content')
-                if bool(self.settings.get_value('autogenerate').unpack()):
+                if bool(self.get_unpacked_settings_value('autogenerate')):
                     threading.Thread(target=self.generate_requested).start()
                 else:
                     self.palette_stack.set_visible_child_name('no-content')
@@ -216,6 +230,13 @@ class PigmentWindow(Adw.ApplicationWindow):
         )
 
         self.settings.bind(
+            'omit-doubled-colors',
+            self.omit_doubled_colors_switch,
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        )
+
+        self.settings.bind(
             'default-format',
             self.default_format_switch,
             'selected',
@@ -235,4 +256,3 @@ class PigmentWindow(Adw.ApplicationWindow):
             'value',
             Gio.SettingsBindFlags.DEFAULT
         )
-

--- a/src/window.ui
+++ b/src/window.ui
@@ -239,6 +239,11 @@
                 </object>
               </child>
               <child>
+                <object class="AdwSwitchRow" id="omit_doubled_colors_switch">
+                  <property name="title" translatable="yes">Omit doubled colors in palette</property>
+                </object>
+              </child>
+              <child>
                 <object class="AdwComboRow" id="default_format_switch">
                   <property name="title" translatable="yes">Default Color Format</property>
                   <property name="model">

--- a/src/window.ui
+++ b/src/window.ui
@@ -240,7 +240,7 @@
               </child>
               <child>
                 <object class="AdwSwitchRow" id="omit_doubled_colors_switch">
-                  <property name="title" translatable="yes">Omit doubled colors in palette</property>
+                  <property name="title" translatable="yes">Omit Doubled Colors in Palette</property>
                 </object>
               </child>
               <child>


### PR DESCRIPTION
Hi yet again,

this commit adds an option for the users to activate in the preferences; it defaults to off. When activated, only unique colors are shown in the palette. Otherwise, if no more different colors are found by ColorThief, the same color may be shown several times.

Have a great day